### PR TITLE
InfoAreaクラスを作成する

### DIFF
--- a/AbstractArea.pde
+++ b/AbstractArea.pde
@@ -1,0 +1,14 @@
+abstract class AbstractArea {
+  int posX;
+  int posY;
+  int tate;
+  int yoko;
+  AbstractArea(int posX, int posY, int yoko, int tate) {
+    this.posX = posX;
+    this.posY = posY;
+    this.yoko = yoko;
+    this.tate = tate;
+  }
+  abstract void draw();
+
+}

--- a/InfoArea.pde
+++ b/InfoArea.pde
@@ -1,0 +1,12 @@
+class InfoArea extends AbstractArea {
+  InfoArea(int posX, int posY, int yoko, int tate) {
+    super(posX, posY, yoko, tate);
+  }
+  void draw() {
+    fill(#FFFFFF);
+    rect(posX*SQUARESIZE, posY*SQUARESIZE, yoko*SQUARESIZE, tate*SQUARESIZE);
+    fill(#000000);
+    textSize(20);
+    text("<- Left turn", (posX+0.3)*SQUARESIZE, (posY+0.5)*SQUARESIZE);
+  }
+}


### PR DESCRIPTION
AbstractAreaクラスを継承する．
親クラス（AbstractAreaクラス）で定義されたエリアの左上座標(poX, posY)と縦幅(tate)，横幅(yoko)を親クラスのコンストラクタ(super(int posX, int posY, int yoko, int tate))を利用して初期化する．
親クラスで定義された抽象メソッドvoid draw()を実装する．
エリア内は白字に黒文字．
起動時はLeftのTurnであることを示す文字を左寄りに表示する．